### PR TITLE
Fix: The width of TreeViewItem is not fully extended.

### DIFF
--- a/src/components/TreeView/__snapshots__/index.stories.tsx.snap
+++ b/src/components/TreeView/__snapshots__/index.stories.tsx.snap
@@ -204,3 +204,107 @@ exports[`View/TreeView Basic smoke-test 1`] = `
   </div>
 </div>
 `;
+
+exports[`View/TreeView Scroll smoke-test 1`] = `
+<div style="width: 256px; padding-bottom: 32px; overflow: auto;">
+  <div class="cmpui_tree-view__root">
+    <ol class="cmpui_tree-view__ol">
+      <li class="cmpui_tree-view__item">
+        <div style="background-color: rgba(0, 0, 0, 0.05); padding-left: 0px; white-space: nowrap;">
+          root
+        </div>
+      </li>
+      <li class="cmpui_tree-view__item-dir">
+        <ol class="cmpui_tree-view__item-dir-ol">
+          <li class="cmpui_tree-view__item">
+            <div style="background-color: rgba(0, 0, 0, 0.1); padding-left: 16px; white-space: nowrap;">
+              child-1
+            </div>
+          </li>
+          <li class="cmpui_tree-view__item-dir">
+            <ol class="cmpui_tree-view__item-dir-ol">
+              <li class="cmpui_tree-view__item">
+                <div style="background-color: rgba(0, 0, 0, 0.15); padding-left: 32px; white-space: nowrap;">
+                  child-1-1
+                </div>
+              </li>
+              <li class="cmpui_tree-view__item-dir">
+                <ol class="cmpui_tree-view__item-dir-ol">
+                  <li class="cmpui_tree-view__item">
+                    <div style="background-color: rgba(0, 0, 0, 0.2); padding-left: 48px; white-space: nowrap;">
+                      child-1-1-1
+                    </div>
+                  </li>
+                  <li class="cmpui_tree-view__item-dir">
+                    <ol class="cmpui_tree-view__item-dir-ol">
+                      <li class="cmpui_tree-view__item">
+                        <div style="background-color: rgba(0, 0, 0, 0.25); padding-left: 64px; white-space: nowrap;">
+                          child-1-1-1-1
+                        </div>
+                      </li>
+                      <li class="cmpui_tree-view__item-dir">
+                        <ol class="cmpui_tree-view__item-dir-ol">
+                          <li class="cmpui_tree-view__item">
+                            <div style="background-color: rgba(0, 0, 0, 0.3); padding-left: 80px; white-space: nowrap;">
+                              child-1-1-1-1-1
+                            </div>
+                          </li>
+                          <li class="cmpui_tree-view__item-dir">
+                            <ol class="cmpui_tree-view__item-dir-ol">
+                              <li class="cmpui_tree-view__item">
+                                <div style="background-color: rgba(0, 0, 0, 0.35); padding-left: 96px; white-space: nowrap;">
+                                  child-1-1-1-1-1-1
+                                </div>
+                              </li>
+                              <li class="cmpui_tree-view__item-dir">
+                                <ol class="cmpui_tree-view__item-dir-ol">
+                                  <li class="cmpui_tree-view__item">
+                                    <div style="background-color: rgba(0, 0, 0, 0.4); padding-left: 112px; white-space: nowrap;">
+                                      child-1-1-1-1-1-1-1
+                                    </div>
+                                  </li>
+                                  <li class="cmpui_tree-view__item-dir">
+                                    <ol class="cmpui_tree-view__item-dir-ol">
+                                      <li class="cmpui_tree-view__item">
+                                        <div style="background-color: rgba(0, 0, 0, 0.45); padding-left: 128px; white-space: nowrap;">
+                                          child-1-1-1-1-1-1-1-1
+                                        </div>
+                                      </li>
+                                      <li class="cmpui_tree-view__item-dir">
+                                        <ol class="cmpui_tree-view__item-dir-ol">
+                                          <li class="cmpui_tree-view__item">
+                                            <div style="background-color: rgba(0, 0, 0, 0.5); padding-left: 144px; white-space: nowrap;">
+                                              child-1-1-1-1-1-1-1-1-1
+                                            </div>
+                                          </li>
+                                          <li class="cmpui_tree-view__item-dir">
+                                            <ol class="cmpui_tree-view__item-dir-ol">
+                                              <li class="cmpui_tree-view__item">
+                                                <div style="background-color: rgba(0, 0, 0, 0.55); padding-left: 160px; white-space: nowrap;">
+                                                  child-1-1-1-1-1-1-1-1-1-1
+                                                </div>
+                                              </li>
+                                            </ol>
+                                          </li>
+                                        </ol>
+                                      </li>
+                                    </ol>
+                                  </li>
+                                </ol>
+                              </li>
+                            </ol>
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol>
+  </div>
+</div>
+`;

--- a/src/components/TreeView/index.css
+++ b/src/components/TreeView/index.css
@@ -10,7 +10,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  width: 100%;
+  width: fit-content;
 }
 
 .cmpui_tree-view__item {
@@ -38,7 +38,7 @@
   pointer-events: none;
   position: absolute;
   top: 0;
-  width: 100px;
+  width: 100%;
   z-index: 100;
   box-sizing: border-box;
 }

--- a/src/components/TreeView/index.stories.tsx
+++ b/src/components/TreeView/index.stories.tsx
@@ -414,3 +414,86 @@ export const Basic: Story = {
     );
   },
 };
+
+export const Scroll: Story = {
+  render: function Render() {
+    return (
+      <div
+        style={{
+          width: 256,
+          paddingBottom: 32,
+          overflow: "auto",
+        }}
+      >
+        <TreeView
+          items={[
+            {
+              id: "root",
+              children: [
+                {
+                  id: "child-1",
+                  children: [
+                    {
+                      id: "child-1-1",
+                      children: [
+                        {
+                          id: "child-1-1-1",
+                          children: [
+                            {
+                              id: "child-1-1-1-1",
+                              children: [
+                                {
+                                  id: "child-1-1-1-1-1",
+                                  children: [
+                                    {
+                                      id: "child-1-1-1-1-1-1",
+                                      children: [
+                                        {
+                                          id: "child-1-1-1-1-1-1-1",
+                                          children: [
+                                            {
+                                              id: "child-1-1-1-1-1-1-1-1",
+                                              children: [
+                                                {
+                                                  id: "child-1-1-1-1-1-1-1-1-1",
+                                                  children: [
+                                                    {
+                                                      id: "child-1-1-1-1-1-1-1-1-1-1",
+                                                    },
+                                                  ],
+                                                },
+                                              ],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ]}
+          render={(props) => (
+            <div
+              style={{
+                backgroundColor: `rgba(0, 0, 0, ${0.05 + props.depth * 0.05})`,
+                paddingLeft: props.depth * 16,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {props.item.id}
+            </div>
+          )}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/TreeView/index.tsx
+++ b/src/components/TreeView/index.tsx
@@ -65,15 +65,16 @@ export function TreeView<T extends ITree>(props: TreeViewProps<T>) {
                 render={props.render}
                 onOrderChange={props.onOrderChange}
                 updateIndicator={props.updateIndicator}
-                onUpdateIndicator={(el, type, depth) => {
+                onUpdateIndicator={(el, type) => {
                   const rootRect = ref.current?.getBoundingClientRect();
                   if (!rootRect) return;
                   const rect = el.getBoundingClientRect();
-
-                  const padLeft = depth * 8;
+                  const child = el.firstElementChild;
+                  if (!child) return;
+                  const padLeft = parseInt(getComputedStyle(child).paddingLeft);
 
                   setX(padLeft);
-                  setWidth(rootRect.width - padLeft - 8);
+                  setWidth(rect.width - padLeft);
                   if (type === OrderType.Child) {
                     setY(rect.top - rootRect.top);
                     setHeight(rect.height);


### PR DESCRIPTION
# What

- Fixed: The `TreeViewItem` width did not extend to the maximum when overflowing.
- Fixed: The TreeView indicator was using a fixed padding value.